### PR TITLE
Сокращение пронаунсов и сохранение рассудка

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -131,7 +131,7 @@
 #define HE_HIM_F		"he/him (Femme Clothes)"
 #define SHE_HER_M		"she/her (Masc Clothes)"
 
-GLOBAL_LIST_INIT(pronouns_list, list(HE_HIM, SHE_HER, THEY_THEM, THEY_THEM_F, IT_ITS, HE_HIM_F, SHE_HER_M))
+GLOBAL_LIST_INIT(pronouns_list, list(HE_HIM, SHE_HER/*, THEY_THEM, THEY_THEM_F, IT_ITS, HE_HIM_F, SHE_HER_M*/))
 
 // Voice types (LETHALSTONE)
 
@@ -139,4 +139,4 @@ GLOBAL_LIST_INIT(pronouns_list, list(HE_HIM, SHE_HER, THEY_THEM, THEY_THEM_F, IT
 #define VOICE_TYPE_FEM	"Feminine"
 #define VOICE_TYPE_ANDR	"Androgynous"
 
-GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM, VOICE_TYPE_ANDR))
+GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM/*, VOICE_TYPE_ANDR*/))

--- a/code/modules/client/customizer/customizers/organ/genitals.dm
+++ b/code/modules/client/customizer/customizers/organ/genitals.dm
@@ -323,8 +323,8 @@
 /datum/customizer_choice/organ/breasts/animal
 	sprite_accessories = list(
 		/datum/sprite_accessory/breasts/pair,
-		/datum/sprite_accessory/breasts/quad,
-		/datum/sprite_accessory/breasts/sextuple,
+//		/datum/sprite_accessory/breasts/quad,
+//		/datum/sprite_accessory/breasts/sextuple,
 		)
 
 /datum/customizer/organ/vagina


### PR DESCRIPTION
Теперь может быть выбрана только 1 пара сисика, а не 2 или даже 3

А ещё удаление ненужной пендосовской ЛГБТ хуйни с пронаунсами